### PR TITLE
Support channels without scales in text-format responses

### DIFF
--- a/src/fdsnws-formats.jl
+++ b/src/fdsnws-formats.jl
@@ -33,6 +33,9 @@ function _parse(::Type{DateTime}, s)
     DateTime(s)
 end
 
+_parse(::Type{String}, s) = s
+_parse(::Type{Union{Missing,T}}, s) where T = isempty(s) ? missing : _parse(T, s)
+
 abstract type FDSNTextResponse end
 
 """
@@ -108,9 +111,9 @@ struct FDSNChannelTextResponse <: FDSNTextResponse
     azimuth::Float64
     dip::Float64
     sensor_description::String
-    scale::Float64
-    scale_frequency::Float64
-    scale_units::String
+    scale::MFloat
+    scale_frequency::MFloat
+    scale_units::MString
     sample_rate::Float64
     starttime::DateTime
     endtime::MDateTime
@@ -129,9 +132,9 @@ function Base.convert(::Type{FDSNChannelTextResponse}, s::AbstractString)
     azimuth = _parse(Float64, tokens[9])
     dip = _parse(Float64, tokens[10])
     sensor_description = tokens[11]
-    scale = _parse(Float64, tokens[12])
-    scale_frequency = _parse(Float64, tokens[13])
-    scale_units = tokens[14]
+    scale = _parse(MFloat, tokens[12])
+    scale_frequency = _parse(MFloat, tokens[13])
+    scale_units = scale === missing ? _parse(MString, tokens[14]) : tokens[14]
     sample_rate = _parse(Float64, tokens[15])
     starttime = _parse(DateTime, tokens[16])
     endtime = _parse(DateTime, tokens[17])

--- a/test/fdsnws.jl
+++ b/test/fdsnws.jl
@@ -76,7 +76,7 @@ using SeisRequests
             @test_throws ArgumentError FDSNDataSelect(code="A.B.C.D", location="A")
             @test_throws ArgumentError FDSNDataSelect(code="A.B.C.D", channel="A")
             @test FDSNDataSelect(code="A,B.C*..D") ==
-            FDSNDataSelect(network="A,B", station="C*", location="", channel="D")
+                FDSNDataSelect(network="A,B", station="C*", location="", channel="D")
         end
         # Conversion of strings to dates
         @test FDSNDataSelect(starttime=Dates.DateTime(2000, 01, 01, 01, 02, 03, 456),
@@ -213,6 +213,12 @@ using SeisRequests
                 "A|B|C|D|1|2|3|4|5|6|E|7|8|F|9|2000-01-01|") ==
                 SeisRequests.FDSNChannelTextResponse("A", "B", "C", "D",
                     1, 2, 3, 4, 5, 6, "E", 7, 8, "F", 9, DateTime(2000), missing)
+            @test convert(SeisRequests.FDSNChannelTextResponse,
+                "XB|ELYSE|02|BDO|4.502384|135.623447|-2613.4|-0.1|90.0|0.0|PRESSURE||||20.0|2018-12-20T07:34:25|2022-12-31T23:59:59") ==
+                SeisRequests.FDSNChannelTextResponse("XB", "ELYSE", "02", "BDO",
+                    4.502384, 135.623447, -2613.4, -0.1, 90, 0, "PRESSURE", missing,
+                    missing, missing, 20, DateTime(2018, 12, 20, 7, 34, 25),
+                    DateTime(2022, 12, 31, 23, 59, 59))
         end
         @testset "FDSNEventTextResponse" begin
             @test convert(SeisRequests.FDSNEventTextResponse,


### PR DESCRIPTION
Non-seismic channels, such as those recording pressue, state
of health and so on, may not contain any information about
scale, scale frequency or scale units.  These appear as empty
fields in the text-format response to a channel-level `FDSNStation`
request.  Allow for such channels by:

- Changing the scale-related fields of `FDSNChannelTextResponse`
  to optionally be `missing`.
- Update the parsing of the fields in these responses to allow for
  parsing `Union{Missing, T} where T` types.
- Test this with some sample output from IRIS for XB.ELYSE.01.BD0.
