### PR TITLE
Add compat bounds for all dependencies

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -46,14 +46,14 @@ jobs:
         run: julia --project -e '
           using Pkg;
           Pkg.add([PackageSpec(url="https://github.com/anowacki/$(pkg).jl")
-              for pkg in ["Geodesics", "StationXML", "Seis"]])'
+              for pkg in ["Geodesics", "Seis"]])'
       # Work around problems with quoting when using PowerShell on Windows by using cmd.exe
       - name: Install unregistered dependencies (Windows)
         if: ${{ matrix.os == 'windows-latest' }}
         run: julia --project -e "
           using Pkg;
           Pkg.add([PackageSpec(url=\"https://github.com/anowacki/$(pkg).jl\")
-              for pkg in [\"Geodesics\", \"StationXML\", \"Seis\"]])"
+              for pkg in [\"Geodesics\", \"Seis\"]])"
 
         shell: cmd
       - uses: julia-actions/julia-buildpkg@v1

--- a/Project.toml
+++ b/Project.toml
@@ -15,6 +15,10 @@ Seis = "dd80f4d8-c2f6-58bd-9bd3-4635f134261d"
 StationXML = "bc702e9c-26b7-573b-a57f-23300c0e5013"
 
 [compat]
+DataStructures = "0.17, 0.18"
+DocStringExtensions = "0.8"
+Geodesics = "0.2"
+HTTP = "0.8, 0.9"
 Parameters = "0.12"
 QuakeML = "0.1.1"
 Seis = "0.3.8"


### PR DESCRIPTION
Manually add compat bounds for all dependencies, and as a side effect, update the CI configuration to remove the manual addition of StationXML now that it is registered.

- CI: Remove manual installation of StationXML
- Add compatibility bounds for all dependencies
