### PR TITLE
Fix DateTime parsing of FDSNWS text responses

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.2'
+          - '1.6'
           - '1'
           - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -23,7 +23,7 @@ Parameters = "0.12"
 QuakeML = "0.1.1"
 Seis = "0.3.8"
 StationXML = "0.2"
-julia = "1.2"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/README.md
+++ b/README.md
@@ -22,8 +22,12 @@ Add SeisRequests like so:
 ```julia
 julia> ] # Type ']' to enter pkg mode
 
-pkg> add https://github.com/anowacki/Geodesics.jl https://github.com/anowacki/Seis.jl https://github.com/anowacki/StationXML.jl https://github.com/anowacki/SeisRequests.jl
+pkg> add https://github.com/anowacki/Geodesics.jl https://github.com/anowacki/Seis.jl https://github.com/anowacki/SeisRequests.jl
 ```
+
+SeisRequests supports the latest
+[long-term support release of Julia](https://julialang.org/downloads/#long_term_support_release),
+requiring v1.6 or newer.
 
 ## Using
 

--- a/src/compat.jl
+++ b/src/compat.jl
@@ -1,6 +1,1 @@
 # Compatibility with older Julia versions
-
-# TODO: Remove when we drop support for v1.0
-@static if VERSION < v"1.2"
-    hasproperty(x, p) = p in propertynames(x)
-end

--- a/src/fdsnws-formats.jl
+++ b/src/fdsnws-formats.jl
@@ -26,11 +26,16 @@ function _parse(T, s)
     v
 end
 
+"Parsing of `DateTime`s truncates the timestamp to the nearest millisecond."
 function _parse(::Type{DateTime}, s)
     # Handle the fact that empty strings are always parsed as valid and
     # give you the date 0001-01-01!
     isempty(s) && return missing
-    DateTime(s)
+    # Remove any extra precision on the date; e.g. "2000-01-01T00:00:00.00000" -> "2000-01-01T00:00:00.000"
+    # Valid dates must be ASCII so an error on the following indexing expression is okay
+    # since it indicates invalid input
+    s′ = length(s) > 23 ? @view(s[begin:(begin+22)]) : s
+    DateTime(s′)
 end
 
 _parse(::Type{String}, s) = s

--- a/test/fdsnws.jl
+++ b/test/fdsnws.jl
@@ -267,5 +267,19 @@ using SeisRequests
             @test_throws ArgumentError convert(SeisRequests.FDSNEventTextResponse,
                 "usp000jv5f|2012-11-07T16:35:46.930|__XXX__|-91.895|24|us|us|us|usp000jv5f|mww|7.4|us|earthquake")
         end
+        @testset "Over-precise dates" begin
+            @test SeisRequests._parse(DateTime, "2000-01-01T00:00:00.123456789") ==
+                DateTime(2000, 1, 1, 0, 0, 0, 123)
+            @test SeisRequests._parse(DateTime, "2000-01-01T00:00:00.1235") ==
+                DateTime(2000, 1, 1, 0, 0, 0, 123)
+            @test convert(SeisRequests.FDSNChannelTextResponse,
+                "TA|A04A||BHZ|48.7197|-122.707001|23.0|0.0|0.0|-90.0|Streckeisen STS-2 G3/Quanterra 330 Linear Phase Co|6.27192E8|0.2|M/S|40.0|2004-09-19T23:45:00.0001|2005-10-16T02:09:59.0009") ==
+                SeisRequests.FDSNChannelTextResponse("TA", "A04A", "", "BHZ",
+                    48.7197, -122.707001, 23.0, 0.0, 0.0, -90.0,
+                    "Streckeisen STS-2 G3/Quanterra 330 Linear Phase Co",
+                    6.27192e8, 0.2, "M/S", 40.0,
+                    DateTime("2004-09-19T23:45:00"),
+                    DateTime("2005-10-16T02:09:59"))
+        end
     end
 end


### PR DESCRIPTION
Some in-the-wild responses to requests using the `"text"` format
contain dates given to greater than millisecond precision.  Since
`DateTime`s only support milliseconds, an error was thrown
when parsing these dates.  Fix the error by manually truncating
strings when parsed as `DateTime`s so only the millisecond part
is retained.
