### PR TITLE
Save sensor burial depth into `meta.burial_depth`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## [0.3.0] - 2025-01-22
+
+### Breaking changes
+- SeisRequests now saves sensor burial depth in the `station.meta.burial_depth`
+  entry, rather than in `station.dep`.  This is for future compatibility with
+  changes to Seis.jl.
+
+[0.3.0]: https://github.com/anowacki/SeisRequests.jl/compare/v0.2.3...v0.3.0

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SeisRequests"
 uuid = "37ba1d8a-44b2-5bbd-9814-465cdc1f4fb5"
 authors = ["Andy Nowacki <a.nowacki@leeds.ac.uk>"]
-version = "0.2.3"
+version = "0.3.0"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"


### PR DESCRIPTION
Rather than saving burial depth in km into `station.dep`, instead save
burial depth in m into `station.meta.burial_depth`.  This if for
compatibility with future changes to Seis.jl.

Also add tests for `get_stations!`.
