### PR TITLE
Change default event request server

### DIFF
--- a/src/SeisRequests.jl
+++ b/src/SeisRequests.jl
@@ -69,7 +69,11 @@ const SERVERS = Dict{String,String}(
     "SCEDC" => "http://service.scedc.caltech.edu",
     )
 
+"Default server for station and waveform requests"
 const DEFAULT_SERVER = "Earthscope"
+
+"Default server for event requests"
+const DEFAULT_EVENT_SERVER = "NEIC"
 
 "Dict describing the common HTTP status codes returned by FDSN services"
 const STATUS_CODES = Dict{Int,String}(

--- a/src/high-level.jl
+++ b/src/high-level.jl
@@ -1039,6 +1039,8 @@ not throw.
 function _check_content_type(response, expected; allowempty=true)
     content_type = HTTP.Messages.header(response, "Content-Type")
     allowempty && isempty(content_type) && return
+    # Only warn on non-UTF-8 charsets
+    content_type = replace(content_type, "; charset=utf-8"=>"")
     content_type != expected &&
         @warn("content type of response is \"$content_type\", " *
               "not \"$expected\" as expected")

--- a/src/high-level.jl
+++ b/src/high-level.jl
@@ -843,7 +843,7 @@ end
 #
 
 """
-    get_events(; server=$(DEFAULT_SERVER), verbose=true, T=Float64, kwargs...) -> events
+    get_events(; server=$(DEFAULT_EVENT_SERVER), verbose=true, T=Float64, kwargs...) -> events
 
 Query `server` for events matching those specified in `kwargs`.
 `events` is a `Vector{Seis.GeogEvent{T}}`, where various useful
@@ -853,8 +853,11 @@ For search options, see [`FDSNEvent`](@ref).
 
 The element type of the `Seis.Event`s returned is set by `T`.
 """
-function get_events(; server=DEFAULT_SERVER, verbose=true, T=Float64, kwargs...)
-    request = FDSNEvent(; kwargs...)
+function get_events(; server=DEFAULT_EVENT_SERVER, verbose=true, T=Float64, kwargs...)
+    # Use 1800-01-01T00:00:00 and 4000-01-01T00:00:00 as impossibly small and
+    # large dates, since typemax/typemin values are too large to be
+    # parsed by most servers.  These will be overridden if set in `kwargs`
+    request = FDSNEvent(; starttime="1800-01-01", endtime="4000-01-01", kwargs...)
     response = get_request(request; server=server, verbose=verbose)
     events = parse_event_response(T, request, response, server)
 end

--- a/test/get_events.jl
+++ b/test/get_events.jl
@@ -343,15 +343,16 @@ import QuakeML
             evts = get_events(starttime="2019-01-01", endtime="2020-01-01",
                 minmagnitude=7.5, format="text", verbose=false)
             @test length(evts) == 3
-            @test evts[1] == Event(lon=-75.2775, lat=-5.8132, dep=122.4,
-                time=DateTime(2019, 05, 26, 07, 41, 15),
-                id="11041250",
+            @test evts[1] == Event(lon=-75.2697, lat=-5.8119, dep=122.57,
+                time=DateTime(2019, 05, 26, 07, 41, 15, 073),
+                id="us60003sc0",
                 meta=Dict(
-                    :catalog=>"NEIC PDE",
-                    :contributor_id=>"us60003sc0,at00ps3pco,pt19146001",
-                    :contributor=>"us", :author=>"at,pt,us",
-                    :mag_type=>"Mww", :mag_author=>"us", :mag=>8.0,
-                    :location_name=>"NORTHERN PERU", :server=>"Earthscope"))
+                    :catalog=>"us",
+                    :contributor_id=>"us60003sc0",
+                    :contributor=>"us", :author=>"us",
+                    :mag_type=>"mww", :mag_author=>"us", :mag=>8.0,
+                    :location_name=>"78 km NE of Navarro, Peru",
+                    :server=>SeisRequests.DEFAULT_EVENT_SERVER))
         end
 
         @testset "Station" begin

--- a/test/high_level.jl
+++ b/test/high_level.jl
@@ -3,6 +3,7 @@
 
 using SeisRequests, Test
 
+import HTTP
 import StationXML
 
 @testset "High-level" begin
@@ -61,5 +62,31 @@ import StationXML
     @testset "_getifnotmissing" begin
         @test SeisRequests._getifnotmissing((a=1, b=missing), :a) == 1
         @test SeisRequests._getifnotmissing(missing, :a) === missing
+    end
+
+    @testset "_check_content_type" begin
+        @test SeisRequests._check_content_type(
+                HTTP.Messages.Response(200, Dict("Content-Type"=>"application/xml")),
+                "application/xml"
+            ) === nothing
+        @test SeisRequests._check_content_type(
+                HTTP.Messages.Response(200, Dict("Content-Type"=>"")),
+                "application/xml";
+                allowempty=true
+            ) === nothing
+        @test SeisRequests._check_content_type(
+                HTTP.Messages.Response(200, Dict("Content-Type"=>"application/xml; charset=utf-8")),
+                "application/xml"
+            ) === nothing
+        @test_logs(
+            (
+                :warn,
+                "content type of response is \"text/xml\", not \"application/xml\" as expected"
+            ),
+            SeisRequests._check_content_type(
+                HTTP.Messages.Response(200, Dict("Content-Type"=>"text/xml")),
+                "application/xml"
+            )
+        )
     end
 end


### PR DESCRIPTION
Because Earthscope are removing their FDSNEvent service, change to
use a different default server (USGS).

- **Update default events request server**
- **Do not warn about charset declarations in content-type HTTP headers**
