### PR TITLE
Update check on IRIS/Earthscope server when posting requests

### DIFF
--- a/src/SeisRequests.jl
+++ b/src/SeisRequests.jl
@@ -233,9 +233,9 @@ function post_request(rs::AbstractArray{T};
     #        so do not include that for compatibility and simply warn
     #        if nodata != 204.
     #        Other datacentres *do* allow this.
-    if server == "IRIS" || server == SERVERS["IRIS"]
+    if server in ("Earthscope", "IRIS") || server == SERVERS["Earthscope"]
         first(rs).nodata != 204 &&
-            @warn("IRIS does not support setting the nodata field in POST " *
+            @warn("Earthscope does not support setting the nodata field in POST " *
                   "requests, but it has a non-default value for this request.")
         body = replace(body, r"^\s*nodata=.*\n"=>"")
     end


### PR DESCRIPTION
IRIS/Earthscope does not support setting the `nodata` field when POSTing
requests, so update the check on the default server name now that we
have renamed IRIS to Earthscope.
